### PR TITLE
fix(InfiniteScroll): non-passive wheel listeners for Chrome preventDefault

### DIFF
--- a/src/components/InfiniteScroll.tsx
+++ b/src/components/InfiniteScroll.tsx
@@ -113,9 +113,14 @@ export const InfiniteScroll = forwardRef<unknown, InfiniteScrollProps>((props, r
 
   useEffect(() => {
     const scrollElement = useWindow ? window : scrollComponent.current?.parentNode;
-    scrollElement?.addEventListener('mousewheel', mousewheelListener, useCapture);
+    if (!scrollElement) return;
+
+    const wheelListenerOptions = { capture: Boolean(useCapture), passive: false as const };
+    scrollElement.addEventListener('wheel', mousewheelListener, wheelListenerOptions);
+    scrollElement.addEventListener('mousewheel', mousewheelListener, wheelListenerOptions);
     return () => {
-      scrollElement?.removeEventListener('mousewheel', mousewheelListener, useCapture);
+      scrollElement.removeEventListener('wheel', mousewheelListener, wheelListenerOptions);
+      scrollElement.removeEventListener('mousewheel', mousewheelListener, wheelListenerOptions);
     };
   }, [useCapture, useWindow]);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 🎯 Goal

Chrome logs `[Intervention] Unable to preventDefault inside passive event listener` when `InfiniteScroll` attaches a `mousewheel` listener on `window` with the legacy boolean capture flag. Browsers default those listeners to `passive: true`, so the existing `deltaY === 1` workaround cannot call `preventDefault()` legally.

### 🛠 Implementation details

In the effect that registers the wheel workaround listener, the third argument is now an options object `{ capture: Boolean(useCapture), passive: false }`. Both `wheel` and `mousewheel` are registered with the same listener function and the same options object so `removeEventListener` matches. This aligns with the approach used in stream-chat-react’s infinite-scroll components.

Local `yarn build` was run so generated `dist/` output stays consistent with source (this repo gitignores `dist/`).

### 🎨 UI Changes

None.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79bad5e1-2745-4425-a307-074699989a9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79bad5e1-2745-4425-a307-074699989a9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

